### PR TITLE
fix(vk_ads_new) Add custom event to statistics stream request, fixed …

### DIFF
--- a/airbyte-integrations/connectors/source-vk-ads-new/source_vk_ads_new/schemas/ad_groups_statistics.json
+++ b/airbyte-integrations/connectors/source-vk-ads-new/source_vk_ads_new/schemas/ad_groups_statistics.json
@@ -377,7 +377,7 @@
       }
     },
     "custom_event": {
-      "type": ["string", "null"]
+      "type": ["object", "string", "null"]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-vk-ads-new/source_vk_ads_new/schemas/ad_plans_statistics.json
+++ b/airbyte-integrations/connectors/source-vk-ads-new/source_vk_ads_new/schemas/ad_plans_statistics.json
@@ -377,7 +377,7 @@
       }
     },
     "custom_event": {
-      "type": ["string", "null"]
+      "type": ["object", "string", "null"]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-vk-ads-new/source_vk_ads_new/schemas/banners_statistics.json
+++ b/airbyte-integrations/connectors/source-vk-ads-new/source_vk_ads_new/schemas/banners_statistics.json
@@ -377,7 +377,7 @@
       }
     },
     "custom_event": {
-      "type": ["string", "null"]
+      "type": ["object", "string", "null"]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-vk-ads-new/source_vk_ads_new/source.py
+++ b/airbyte-integrations/connectors/source-vk-ads-new/source_vk_ads_new/source.py
@@ -159,7 +159,8 @@ class StatisticsStream(VkAdsNewStream, HttpSubStream, ABC):
             **VkAdsNewStream.request_params(self, stream_slice=stream_slice, *args, **kwargs),
             "date_from": self.date_from.strftime("%Y-%m-%d"),
             "date_to": self.date_to.strftime("%Y-%m-%d"),
-            "metrics": "all",
+            "metrics": "all,custom_event",
+            "custom_events": "custom_event_41",
             **stream_slice,
         }
 


### PR DESCRIPTION
Добавил в StatisticsStream в request_params поле "custom_event": "custom_event_41"
Это поле подсказала поддержка, в документации об кастомных полях практически ничего не написано, но этот вариант добавляет тем записям, у которых есть что-то в events, поля custom_event_41_likes, custom_event_41_shares, custom_event_41_joins, т.е данные о том, сколько людей поделилось записью, поставили лайки и т.д

Пока Таня отвечает, это будет в PR, как она подтвердит - солью. У себя выгружал 3 стрима с постфиксом _statistics
https://adventum.kaiten.ru/space/339647/boards/card/43881640

UPD: Таня подтвердила, что все ок, можно задачу закрывать