### PR TITLE
feature(YandexDirect) Add logging for streams

### DIFF
--- a/airbyte-integrations/connectors/source-yandex-direct/source_yandex_direct/ads_streams.py
+++ b/airbyte-integrations/connectors/source-yandex-direct/source_yandex_direct/ads_streams.py
@@ -8,7 +8,7 @@ from airbyte_cdk.sources.streams.http.auth import TokenAuthenticator
 from airbyte_cdk.sources.utils.transform import TransformConfig, TypeTransformer
 from .schema_fields import AD_IMAGES_DEFAULT_FIELDS, ADS_DEFAULT_FIELDS, CAMPAIGNS_DEFAULT_FIELDS
 
-from .utils import chunks, concat_multiple_lists, find_by_key, get_unique
+from .utils import chunks, concat_multiple_lists, find_by_key, get_unique, log_stream_request_data
 
 
 class YandexDirectAdsStream(HttpStream, ABC):
@@ -126,6 +126,19 @@ class Campaigns(YandexDirectAdsStream):
             request_object,
             next_page_token,
         )
+
+        # logging request body and url
+        log_stream_request_data(
+            stream_name="Campaigns",
+            data=body,
+            section="body"
+        )
+        log_stream_request_data(
+            stream_name="Campaigns",
+            data=f"{self.url_base}{self.path()}",
+            section="url"
+        )
+
         return body
 
     def path(self, *args, **kwargs) -> str:
@@ -154,6 +167,19 @@ class Ads(YandexDirectAdsStream, DependsOnParentIdsSubStream):
             request_object,
             next_page_token,
         )
+
+        # logging request body and url
+        log_stream_request_data(
+            stream_name="Ads",
+            data=body,
+            section="body"
+        )
+        log_stream_request_data(
+            stream_name="Ads",
+            data=f"{self.url_base}{self.path()}",
+            section="url"
+        )
+
         return body
 
 
@@ -183,6 +209,19 @@ class AdImages(YandexDirectAdsStream, DependsOnParentIdsSubStream):
             request_object,
             next_page_token,
         )
+
+        # logging request body and url
+        log_stream_request_data(
+            stream_name="AdImages",
+            data=body,
+            section="body"
+        )
+        log_stream_request_data(
+            stream_name="AdImages",
+            data=f"{self.url_base}{self.path()}",
+            section="url"
+        )
+
         return body
 
     def stream_slices(

--- a/airbyte-integrations/connectors/source-yandex-direct/source_yandex_direct/report_streams.py
+++ b/airbyte-integrations/connectors/source-yandex-direct/source_yandex_direct/report_streams.py
@@ -16,7 +16,7 @@ from airbyte_cdk.sources.streams.http.requests_native_auth import TokenAuthentic
 from airbyte_cdk.sources.utils.schema_helpers import ResourceSchemaLoader
 
 from .schema_fields import CUSTOM_SCHEMA_FIELDS, build_goal_fields
-from .utils import HttpAvailabilityStrategy, random_name, split_date_by_chunks
+from .utils import HttpAvailabilityStrategy, random_name, split_date_by_chunks, log_stream_request_data
 
 logger = airbyte_logger.AirbyteLogger()
 
@@ -177,6 +177,13 @@ class CustomReport(YandexDirectStream):
 
         if self.parsed_filters:
             params["params"]["SelectionCriteria"]["Filter"] = self.parsed_filters
+
+        log_stream_request_data(
+            stream_name="Custom Report",
+            data=params,
+            section="body"
+        )
+
         return params
 
     def request_headers(self, *args, **kwargs) -> Mapping[str, Any]:
@@ -189,6 +196,19 @@ class CustomReport(YandexDirectStream):
         headers.update(self.authenticator.get_auth_header())
         if self.client_login:
             headers["Client-Login"] = self.client_login
+
+        # logging headers and url
+        log_stream_request_data(
+            stream_name="Custom Report",
+            data=headers,
+            section="headers"
+        )
+        log_stream_request_data(
+            stream_name="Custom Report",
+            data=self.url_base,
+            section="url"
+        )
+
         return headers
 
     @lru_cache(maxsize=None)


### PR DESCRIPTION
Написал функцию логгирования, которая используется в стримах
Сейчас она выводит: заголовки, тела запросов, url

Сейчас на проверке у Тани. Залито на dockerhub под версией 1.1.0