### PR TITLE
Fix comagic, vk-ads-new, arsenkin, also fix a typo

### DIFF
--- a/airbyte-integrations/connectors/destination-yandex-metrica-offline-conv/destination_yandex_metrica_offline_conv/spec.json
+++ b/airbyte-integrations/connectors/destination-yandex-metrica-offline-conv/destination_yandex_metrica_offline_conv/spec.json
@@ -59,7 +59,7 @@
               },
               "credentials_craft_token_id": {
                 "title": "CredentialsCraft Yandex Token ID",
-                "desctiption": "Yandex Token ID in CredentialsCraft",
+                "description": "Yandex Token ID in CredentialsCraft",
                 "examples": [3345435],
                 "type": "integer"
               }

--- a/airbyte-integrations/connectors/source-adjust/source_adjust/spec.json
+++ b/airbyte-integrations/connectors/source-adjust/source_adjust/spec.json
@@ -65,7 +65,7 @@
               },
               "credentials_craft_token_id" : {
                 "title" : "CredentialsCraft Adjust Token ID",
-                "desctiption" : "Adjust Token ID in CredentialsCraft",
+                "description" : "Adjust Token ID in CredentialsCraft",
                 "examples" : [
                   123
                 ],

--- a/airbyte-integrations/connectors/source-appmetrica-logs-api/source_appmetrica_logs_api/spec.json
+++ b/airbyte-integrations/connectors/source-appmetrica-logs-api/source_appmetrica_logs_api/spec.json
@@ -64,7 +64,7 @@
               },
               "credentials_craft_token_id" : {
                 "title" : "CredentialsCraft Yandex Token ID",
-                "desctiption" : "Yandex Token ID in CredentialsCraft",
+                "description" : "Yandex Token ID in CredentialsCraft",
                 "examples" : [
                   3345435
                 ],

--- a/airbyte-integrations/connectors/source-appmetrika-logs-stream-api/source_appmetrika_logs_stream_api/spec.json
+++ b/airbyte-integrations/connectors/source-appmetrika-logs-stream-api/source_appmetrika_logs_stream_api/spec.json
@@ -56,7 +56,7 @@
               },
               "credentials_craft_token_id": {
                 "title": "CredentialsCraft Yandex Token ID",
-                "desctiption": "Yandex Token ID in CredentialsCraft",
+                "description": "Yandex Token ID in CredentialsCraft",
                 "examples": [3345435],
                 "type": "integer"
               }

--- a/airbyte-integrations/connectors/source-arsenkin/source_arsenkin/spec.json
+++ b/airbyte-integrations/connectors/source-arsenkin/source_arsenkin/spec.json
@@ -78,6 +78,115 @@
             "Автомобиль БУ"
           ]
         }
+      },
+      "date_range": {
+        "title": "Date Range",
+        "description": "Choose date period that must be loaded (Dates are not currently in use.)",
+        "type": "object",
+        "order": 4,
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "Custom Date Range",
+            "properties": {
+              "date_from": {
+                "title": "Start Date",
+                "type": "string",
+                "description": "Start date in format YYYY-MM-DD.",
+                "pattern": "^$|^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+                "pattern_descriptor": "YYYY-MM-DD",
+                "examples": [
+                  "2023-01-01"
+                ],
+                "format": "date",
+                "order": 0
+              },
+              "date_to": {
+                "title": "End Date",
+                "type": "string",
+                "description": "End date in format YYYY-MM-DD.",
+                "pattern": "^$|^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+                "examples": [
+                  "2023-01-30"
+                ],
+                "pattern_descriptor": "YYYY-MM-DD",
+                "format": "date",
+                "order": 1
+              },
+              "date_range_type": {
+                "type": "string",
+                "title": "Date Range Type",
+                "description": "Custom Date",
+                "const": "custom_date",
+                "order": 2
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "Last N Days",
+            "properties": {
+              "last_days_count": {
+                "title": "Last Days Count",
+                "type": "integer",
+                "description": "Count of last days exclude today.",
+                "minimum": 0,
+                "maximum": 3650,
+                "examples": [
+                  30
+                ],
+                "order": 0
+              },
+              "should_load_today": {
+                "title": "Load Today?",
+                "type": "boolean",
+                "description": "Should connector load today time as End Time? If not, End Time will be yesterday.",
+                "order": 1,
+                "default": false
+              },
+              "date_range_type": {
+                "type": "string",
+                "title": "Date Range Type",
+                "description": "Last N Days",
+                "const": "last_n_days",
+                "order": 2
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "From Start Date To Today",
+            "description": "Load data from Start Date to Today. Only with this option you can use incremental sync.",
+            "properties": {
+              "date_from": {
+                "title": "Start Date",
+                "type": "string",
+                "description": "Start date in format YYYY-MM-DD.",
+                "pattern": "^$|^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+                "pattern_descriptor": "YYYY-MM-DD",
+                "examples": [
+                  "2023-01-01"
+                ],
+                "format": "date",
+                "order": 0
+              },
+              "should_load_today": {
+                "title": "Load Today?",
+                "type": "boolean",
+                "description": "Should connector load today date as End Date? If not, End Date will be yesterday.",
+                "order": 1,
+                "default": false
+              },
+              "date_range_type": {
+                "type": "string",
+                "title": "Date Range Type",
+                "description": "From start date to today",
+                "const": "from_start_date_to_today",
+                "order": 2
+              }
+            }
+          }
+        ]
       }
     }
   }

--- a/airbyte-integrations/connectors/source-bitrix24-crm/source_bitrix24_crm/spec.json
+++ b/airbyte-integrations/connectors/source-bitrix24-crm/source_bitrix24_crm/spec.json
@@ -64,7 +64,7 @@
               },
               "credentials_craft_token_id" : {
                 "title" : "ID авторизации в CredentialsCraft",
-                "desctiption" : "ID авторизации Yandex внутри CredentialsCraft",
+                "description" : "ID авторизации Yandex внутри CredentialsCraft",
                 "examples" : [
                   3345435
                 ],

--- a/airbyte-integrations/connectors/source-comagic/Dockerfile
+++ b/airbyte-integrations/connectors/source-comagic/Dockerfile
@@ -1,5 +1,5 @@
 #FROM python:3.7.11-alpine3.14 as base
-FROM python:3.9-alpine as base
+FROM python:3.9.11-alpine as base
 
 # build and load all requirements
 FROM base as builder

--- a/airbyte-integrations/connectors/source-comagic/setup.py
+++ b/airbyte-integrations/connectors/source-comagic/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.2",
+    "airbyte-cdk~=0.58.8",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-comagic/source_comagic/auth.py
+++ b/airbyte-integrations/connectors/source-comagic/source_comagic/auth.py
@@ -1,0 +1,62 @@
+from typing import Any, Mapping
+
+import requests
+from airbyte_cdk.sources.streams.http.requests_native_auth import TokenAuthenticator
+
+
+class CredentialsCraftAuthenticator(TokenAuthenticator):
+    def __init__(
+        self,
+        credentials_craft_host: str,
+        credentials_craft_token: str,
+        credentials_craft_token_id: int,
+        additional_headers: dict = {},
+    ):
+        self._cc_host = credentials_craft_host.rstrip("/")
+        self._cc_token = credentials_craft_token
+        self._cc_token_id = credentials_craft_token_id
+        self._token = None
+        self.additional_headers = additional_headers
+
+    @property
+    def _url(self) -> str:
+        return f"{self._cc_host}/api/v1/token/static/{self._cc_token_id}/"
+
+    @property
+    def token(self) -> dict[str, str]:
+        """
+        Returns {"login": "some_login", "password": "some_password"}
+        """
+        response = requests.get(
+            self._url,
+            headers={"Authorization": f"Bearer {self._cc_token}"},
+        )
+        response.raise_for_status()
+        data: dict[str, Any] = response.json()
+        return data["token_data"]
+
+    def get_auth_header(self) -> Mapping[str, Any]:
+        super().__init__(self.token, "Bearer", "Authorization")
+        auth_header = {self.auth_header: f"{self._auth_method} {self.token}"}
+        if self.additional_headers:
+            auth_header.update(self.additional_headers)
+        return auth_header
+
+    def check_connection(self) -> tuple[bool, str]:
+        try:
+            requests.get(self._cc_host, timeout=15)
+        except Exception as e:
+            return False, f"Connection to {self._cc_host} timed out: {e}"
+
+        response = requests.get(
+            self._url,
+            headers={"Authorization": f"Bearer {self._cc_token}"},
+        )
+        if response.status_code != 200:
+            return False, f"CredentialsCraft error: {response.text}"
+
+        data: dict[str, Any] = response.json()
+        if data.get("error"):
+            return False, f"CredentialsCraft error: {data.get('error')}"
+
+        return True, None

--- a/airbyte-integrations/connectors/source-comagic/source_comagic/spec.json
+++ b/airbyte-integrations/connectors/source-comagic/source_comagic/spec.json
@@ -7,16 +7,80 @@
     "required": [],
     "additionalProperties": true,
     "properties": {
-      "login": {
-        "type": "string",
-        "description": "Comagic account login",
-        "order": 0
-      },
-      "password": {
-        "type": "string",
-        "description": "Comagic account password",
-        "airbyte_secret": true,
-        "order": 1
+      "credentials": {
+        "title": "Auth method",
+        "order": 0,
+        "type": "object",
+        "group": "auth",
+        "oneOf": [
+          {
+            "title": "Login and Password",
+            "type": "object",
+            "properties": {
+              "auth_type": {
+                "title": "Auth Type",
+                "const": "access_token_auth",
+                "order": 0,
+                "type": "string"
+              },
+              "login": {
+                "type": "string",
+                "description": "Comagic account login",
+                "order": 1
+              },
+              "password": {
+                "type": "string",
+                "description": "Comagic account password",
+                "airbyte_secret": true,
+                "order": 2
+              }
+            },
+            "required": [
+              "login",
+              "password"
+            ]
+          },
+          {
+            "title": "CredentialsCraft",
+            "type": "object",
+            "properties": {
+              "auth_type": {
+                "title": "Auth Type",
+                "const": "credentials_craft_auth",
+                "order": 0,
+                "type": "string"
+              },
+              "credentials_craft_host": {
+                "title": "CredentialsCraft Host",
+                "description": "CredentialsCraft Host Url",
+                "examples": [
+                  "https://credentialscraft.mysite.com"
+                ],
+                "type": "string"
+              },
+              "credentials_craft_token": {
+                "title": "CredentialsCraft Token",
+                "description": "Long-term CredentialsCraft Access Token",
+                "type": "string",
+                "airbyte_secret": true
+              },
+              "credentials_craft_token_id": {
+                "title": "CredentialsCraft Comagic Token ID",
+                "description": "Comagic Token Id in CredentialsCraft",
+                "examples": [
+                  3345435
+                ],
+                "type": "integer"
+              }
+            },
+            "required": [
+              "auth_type",
+              "credentials_craft_host",
+              "credentials_craft_token",
+              "credentials_craft_token_id"
+            ]
+          }
+        ]
       },
       "site_id": {
         "title": "Site ID",
@@ -25,13 +89,13 @@
         "examples": [
           "22334"
         ],
-        "order": 2
+        "order": 1
       },
       "date_range": {
         "title": "Date Range",
         "description": "Choose date period that must be loaded",
         "type": "object",
-        "order": 3,
+        "order": 2,
         "oneOf": [
           {
             "type": "object",
@@ -158,7 +222,7 @@
         "examples": [
           "abcde"
         ],
-        "order": 4,
+        "order": 3,
         "default": ""
       },
       "product_name": {
@@ -168,7 +232,7 @@
         "examples": [
           "abcde"
         ],
-        "order": 5,
+        "order": 4,
         "default": ""
       },
       "custom_constants": {
@@ -179,7 +243,7 @@
           "{\"abc\": \"123\", \"cde\": \"132\"}"
         ],
         "default": "{}",
-        "order": 6
+        "order": 5
       }
     }
   }

--- a/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/spec.json
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/spec.json
@@ -36,7 +36,7 @@
               },
               "credentials_craft_token_id": {
                 "title": "CredentialsCraft Google Token ID",
-                "desctiption": "Google Token ID in CredentialsCraft",
+                "description": "Google Token ID in CredentialsCraft",
                 "examples": [3345435],
                 "type": "integer"
               }

--- a/airbyte-integrations/connectors/source-huawei-ads/source_huawei_ads/spec.json
+++ b/airbyte-integrations/connectors/source-huawei-ads/source_huawei_ads/spec.json
@@ -55,7 +55,7 @@
               },
               "credentials_craft_token_id": {
                 "title": "CredentialsCraft Huawei Ads Token ID",
-                "desctiption": "Huawei Ads Token ID in CredentialsCraft",
+                "description": "Huawei Ads Token ID in CredentialsCraft",
                 "examples": [3345435],
                 "type": "integer"
               }

--- a/airbyte-integrations/connectors/source-mytarget/source_mytarget/spec.json
+++ b/airbyte-integrations/connectors/source-mytarget/source_mytarget/spec.json
@@ -64,7 +64,7 @@
               },
               "credentials_craft_token_id": {
                 "title": "CredentialsCraft MyTarget Token ID",
-                "desctiption": "MyTarget Token ID in CredentialsCraft",
+                "description": "MyTarget Token ID in CredentialsCraft",
                 "examples": [
                   3345435
                 ],

--- a/airbyte-integrations/connectors/source-sipuni/source_sipuni/spec.json
+++ b/airbyte-integrations/connectors/source-sipuni/source_sipuni/spec.json
@@ -65,7 +65,7 @@
               },
               "credentials_craft_token_id" : {
                 "title" : "CredentialsCraft Adjust Token ID",
-                "desctiption" : "Adjust Token ID in CredentialsCraft",
+                "description" : "Adjust Token ID in CredentialsCraft",
                 "examples" : [
                   123
                 ],

--- a/airbyte-integrations/connectors/source-uis/source_uis/spec.json
+++ b/airbyte-integrations/connectors/source-uis/source_uis/spec.json
@@ -62,7 +62,7 @@
               },
               "credentials_craft_token_id" : {
                 "title" : "ID авторизации в CredentialsCraft",
-                "desctiption" : "ID авторизации UIS внутри CredentialsCraft",
+                "description" : "ID авторизации UIS внутри CredentialsCraft",
                 "examples" : [
                   3345435
                 ],

--- a/airbyte-integrations/connectors/source-vk-ads-new/source_vk_ads_new/source.py
+++ b/airbyte-integrations/connectors/source-vk-ads-new/source_vk_ads_new/source.py
@@ -323,14 +323,14 @@ class SourceVkAdsNew(AbstractSource):
         if range_type == "custom_date":
             prepared_range["date_from"] = date_range["date_from"]
             prepared_range["date_to"] = date_range["date_to"]
-        elif range_type == "from_date_from_to_today":
+        elif range_type == "from_start_date_to_today":
             prepared_range["date_from"] = date_range["date_from"]
             if date_range["should_load_today"]:
                 prepared_range["date_to"] = today
             else:
                 prepared_range["date_to"] = today - timedelta(days=1)
         elif range_type == "last_n_days":
-            prepared_range["date_from"] = today - timedelta(days=date_range["last_days"])
+            prepared_range["date_from"] = today - timedelta(days=date_range["last_days_count"])
             if date_range["should_load_today"]:
                 prepared_range["date_to"] = today
             else:

--- a/airbyte-integrations/connectors/source-vk-ads-new/source_vk_ads_new/spec.json
+++ b/airbyte-integrations/connectors/source-vk-ads-new/source_vk_ads_new/spec.json
@@ -55,7 +55,7 @@
               },
               "credentials_craft_token_id": {
                 "title": "CredentialsCraft VK Ads Token ID",
-                "desctiption": "VK Ads Token ID in CredentialsCraft",
+                "description": "VK Ads Token ID in CredentialsCraft",
                 "examples": [3345435],
                 "type": "integer"
               }
@@ -109,12 +109,12 @@
             "type": "object",
             "title": "Last N Days",
             "required": [
-              "last_days",
+              "last_days_count",
               "should_load_today",
               "date_range_type"
             ],
             "properties": {
-              "last_days": {
+              "last_days_count": {
                 "title": "Last Days Count",
                 "type": "integer",
                 "description": "Count of last days exclude today.",
@@ -136,6 +136,44 @@
                 "description": "Last N Days",
                 "const": "last_n_days",
                 "order": 1
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "From Start Date To Today",
+            "description": "Load data from Start Date to Today. Only with this option you can use incremental sync.",
+            "required": [
+              "date_from",
+              "should_load_today",
+              "date_range_type"
+            ],
+            "properties": {
+              "date_from": {
+                "title": "Start Date",
+                "type": "string",
+                "description": "Start date in format YYYY-MM-DD.",
+                "pattern": "^$|^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+                "pattern_descriptor": "YYYY-MM-DD",
+                "examples": [
+                  "2023-01-01"
+                ],
+                "format": "date",
+                "order": 0
+              },
+              "should_load_today": {
+                "title": "Load Today?",
+                "type": "boolean",
+                "description": "Should connector load today date as End Date? If not, End Date will be yesterday.",
+                "order": 1,
+                "default": false
+              },
+              "date_range_type": {
+                "type": "string",
+                "title": "Date Range Type",
+                "description": "From start date to today",
+                "const": "from_start_date_to_today",
+                "order": 2
               }
             }
           }

--- a/airbyte-integrations/connectors/source-vk-ads/source_vk_ads/spec.json
+++ b/airbyte-integrations/connectors/source-vk-ads/source_vk_ads/spec.json
@@ -64,7 +64,7 @@
               },
               "credentials_craft_token_id": {
                 "title": "CredentialsCraft VK Token ID",
-                "desctiption": "VK Token ID in CredentialsCraft",
+                "description": "VK Token ID in CredentialsCraft",
                 "examples": [
                   3345435
                 ],

--- a/airbyte-integrations/connectors/source-vk/source_vk/spec.json
+++ b/airbyte-integrations/connectors/source-vk/source_vk/spec.json
@@ -66,7 +66,7 @@
               },
               "credentials_craft_token_id": {
                 "title": "ID Токена в CredentialsCraft",
-                "desctiption": "ID токена ВК в сервисе CredentialsCraft",
+                "description": "ID токена ВК в сервисе CredentialsCraft",
                 "examples": [
                   123
                 ],

--- a/airbyte-integrations/connectors/source-vkusvill/source_vkusvill/spec.json
+++ b/airbyte-integrations/connectors/source-vkusvill/source_vkusvill/spec.json
@@ -77,7 +77,7 @@
               },
               "credentials_craft_token_id": {
                 "title": "ID авторизации в CredentialsCraft",
-                "desctiption": "ID авторизации Вкусвилл внутри CredentialsCraft",
+                "description": "ID авторизации Вкусвилл внутри CredentialsCraft",
                 "examples": [
                   3345435
                 ],

--- a/airbyte-integrations/connectors/source-yandex-direct-ads/source_yandex_direct_ads/spec.json
+++ b/airbyte-integrations/connectors/source-yandex-direct-ads/source_yandex_direct_ads/spec.json
@@ -56,7 +56,7 @@
               },
               "credentials_craft_token_id": {
                 "title": "CredentialsCraft Yandex Token ID",
-                "desctiption": "Yandex Token ID in CredentialsCraft",
+                "description": "Yandex Token ID in CredentialsCraft",
                 "examples": [3345435],
                 "type": "integer"
               }

--- a/airbyte-integrations/connectors/source-yandex-direct/source_yandex_direct/spec.json
+++ b/airbyte-integrations/connectors/source-yandex-direct/source_yandex_direct/spec.json
@@ -64,7 +64,7 @@
               },
               "credentials_craft_token_id": {
                 "title": "ID авторизации в CredentialsCraft",
-                "desctiption": "ID авторизации Yandex внутри CredentialsCraft",
+                "description": "ID авторизации Yandex внутри CredentialsCraft",
                 "examples": [
                   3345435
                 ],

--- a/airbyte-integrations/connectors/source-yandex-disk/source_yandex_disk/spec.json
+++ b/airbyte-integrations/connectors/source-yandex-disk/source_yandex_disk/spec.json
@@ -56,7 +56,7 @@
               },
               "credentials_craft_token_id": {
                 "title": "CredentialsCraft Yandex Token ID",
-                "desctiption": "Yandex Token ID in CredentialsCraft",
+                "description": "Yandex Token ID in CredentialsCraft",
                 "examples": [3345435],
                 "type": "integer"
               }

--- a/airbyte-integrations/connectors/source-yandex-market/source_yandex_market/spec.json
+++ b/airbyte-integrations/connectors/source-yandex-market/source_yandex_market/spec.json
@@ -63,7 +63,7 @@
               },
               "credentials_craft_token_id": {
                 "title": "CredentialsCraft Yandex Token ID",
-                "desctiption": "Yandex Token ID in CredentialsCraft",
+                "description": "Yandex Token ID in CredentialsCraft",
                 "examples": [
                   3345435
                 ],

--- a/airbyte-integrations/connectors/source-yandex-metrika-report/source_yandex_metrika_report/spec.yaml
+++ b/airbyte-integrations/connectors/source-yandex-metrika-report/source_yandex_metrika_report/spec.yaml
@@ -50,7 +50,7 @@ connectionSpecification:
               airbyte_secret: true
             credentials_craft_token_id:
               title: CredentialsCraft Yandex Token ID
-              desctiption: Yandex Token ID in CredentialsCraft
+              description: Yandex Token ID in CredentialsCraft
               examples:
                 - 3345435
               type: integer
@@ -92,7 +92,7 @@ connectionSpecification:
           preset_name:
             type: string
             title: Preset Name
-            desctiption: See https://yandex.ru/dev/metrika/doc/api2/api_v1/presets/presets.html. Leave empty for Custom Report type
+            description: See https://yandex.ru/dev/metrika/doc/api2/api_v1/presets/presets.html. Leave empty for Custom Report type
             order: 1
           metrics:
             type: array

--- a/airbyte-integrations/connectors/source-yandex-metrika-report/spec.json
+++ b/airbyte-integrations/connectors/source-yandex-metrika-report/spec.json
@@ -57,7 +57,7 @@
                 },
                 "credentials_craft_token_id": {
                   "title": "CredentialsCraft Yandex Token ID",
-                  "desctiption": "Yandex Token ID in CredentialsCraft",
+                  "description": "Yandex Token ID in CredentialsCraft",
                   "examples": [3345435],
                   "type": "integer"
                 }
@@ -102,7 +102,7 @@
               "preset_name": {
                 "type": "string",
                 "title": "Preset Name",
-                "desctiption": "See https://yandex.ru/dev/metrika/doc/api2/api_v1/presets/presets.html. Leave empty for Custom Report type",
+                "description": "See https://yandex.ru/dev/metrika/doc/api2/api_v1/presets/presets.html. Leave empty for Custom Report type",
                 "order": 1
               },
               "metrics": {

--- a/airbyte-integrations/connectors/source-yandex-metrika/source_yandex_metrika/spec.json
+++ b/airbyte-integrations/connectors/source-yandex-metrika/source_yandex_metrika/spec.json
@@ -64,7 +64,7 @@
               },
               "credentials_craft_token_id" : {
                 "title" : "ID авторизации в CredentialsCraft",
-                "desctiption" : "ID авторизации Yandex внутри CredentialsCraft",
+                "description" : "ID авторизации Yandex внутри CredentialsCraft",
                 "examples" : [
                   3345435
                 ],
@@ -109,7 +109,7 @@
               "type" : "string",
               "title" : "Шаблон",
               "always_show" : true,
-              "desctiption" : "Документация: https://yandex.ru/dev/metrika/doc/api2/api_v1/presets/presets.html",
+              "description" : "Документация: https://yandex.ru/dev/metrika/doc/api2/api_v1/presets/presets.html",
               "enum" : [
                 "Пользовательский отчёт",
                 "Источники, сводка",

--- a/airbyte-integrations/connectors/source-yandex-promopages/source_yandex_promopages/spec.json
+++ b/airbyte-integrations/connectors/source-yandex-promopages/source_yandex_promopages/spec.json
@@ -63,7 +63,7 @@
               },
               "credentials_craft_token_id": {
                 "title": "CredentialsCraft Yandex Token ID",
-                "desctiption": "Yandex Token ID in CredentialsCraft",
+                "description": "Yandex Token ID in CredentialsCraft",
                 "examples": [
                   3345435
                 ],


### PR DESCRIPTION
Вторая итерация стандартизации коннекторов: поправлена опечатка, добавлено CC auth в comagic, добавлена дата (в spec.json как заглушка) в arsenkin

arsenkin - версия 0.0.2
comagic - версия 0.0.2
vk-ads-new - версия 0.3.1

Comagic поддерживает такой формат статического токена(token_data) : {"login": "some_login", "password": "some_password"}, и потом, в процессе, получается access_token, как и при обычной авторизации