### PR TITLE
Add event_name_list in spec.json

### DIFF
--- a/airbyte-integrations/connectors/source-appmetrica-logs-api/source_appmetrica_logs_api/source.py
+++ b/airbyte-integrations/connectors/source-appmetrica-logs-api/source_appmetrica_logs_api/source.py
@@ -42,7 +42,9 @@ class SourceAppmetricaLogsApi(AbstractSource):
                     headers={"Authorization": f"OAuth {stream._token}"},
                     params=params,
                 )
-                assert response.status_code in (200, 202, 204)
+                # 429 means ok, but the Yandex server is processing previous requests,
+                # the queue for new ones is still full
+                assert response.status_code in (200, 202, 204, 429)
                 return True, None
             elif isinstance(stream, AppmetricaReportsTable):
                 next(streams[0].read_records(sync_mode=SyncMode.full_refresh))

--- a/airbyte-integrations/connectors/source-appmetrica-logs-api/source_appmetrica_logs_api/spec.json
+++ b/airbyte-integrations/connectors/source-appmetrica-logs-api/source_appmetrica_logs_api/spec.json
@@ -168,12 +168,22 @@
               ],
               "default" : "default"
             },
+            "event_name_list": {
+              "title": "Event Name List",
+              "description": "Used for source type 'events', here you can specify the names of events to get, the rest will be skipped",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "examples": ["view_cart", "add_to_cart", "begin_checkout", "purchase", "select_content", "screen_view"],
+              "order": 5
+            },
             "check_fields" : {
               "title" : "Validate Fields",
               "description" : "Check if field list is correct before making requests",
               "type" : "boolean",
               "default" : true,
-              "order" : 5
+              "order" : 6
             }
           }
         }


### PR DESCRIPTION
- Добавил event_name_list в схему, чтобы можно было фильтровать по событиям стрим events

- Поправил проверку соединения, добавил обработку 429 кода, иначе коннектор не конфигугировался

- Добавил обработку 429 кода в read_records, если очередь на формирование ответа на стороне яндекса была заполнена, то коннектор возвращал без объяснения 0 записей.
Сейчас он будет в таком случае отправлять запросы до момента, когда: очередь освободится, ответ сформируется и выгрузится в БД