### PR TITLE
Back/bugfix/appmetrica not loading records/1940

### DIFF
--- a/airbyte-integrations/connectors/source-appmetrica-logs-api/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-appmetrica-logs-api/integration_tests/configured_catalog.json
@@ -2,7 +2,7 @@
   "streams": [
     {
       "stream": {
-        "name": "test_table",
+        "name": "events",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh"]
       },

--- a/airbyte-integrations/connectors/source-appmetrica-logs-api/source_appmetrica_logs_api/source.py
+++ b/airbyte-integrations/connectors/source-appmetrica-logs-api/source_appmetrica_logs_api/source.py
@@ -28,11 +28,17 @@ class SourceAppmetricaLogsApi(AbstractSource):
         try:
             stream = streams[0]
             if isinstance(stream, AppmetricaLogsApi):
-                stream_slices = list(stream.stream_slices(sync_mode=SyncMode.full_refresh, stream_state=None))
+                stream_slices = list(
+                    stream.stream_slices(
+                        sync_mode=SyncMode.full_refresh, stream_state=None
+                    )
+                )
                 first_slice = stream_slices[0] if stream_slices else None
                 params = {
                     "application_id": stream.application_id,
-                    "date_since": first_slice["date_from"].format(stream.datetime_format),
+                    "date_since": first_slice["date_from"].format(
+                        stream.datetime_format
+                    ),
                     "date_until": first_slice["date_to"].format(stream.datetime_format),
                     "fields": ",".join(stream.fields),
                     "date_dimension": stream.date_dimension,
@@ -50,7 +56,9 @@ class SourceAppmetricaLogsApi(AbstractSource):
                 next(streams[0].read_records(sync_mode=SyncMode.full_refresh))
                 return True, None
             else:
-                raise Exception(f"Connection check is not supported for class {stream.__class__.__name__}")
+                raise Exception(
+                    f"Connection check is not supported for class {stream.__class__.__name__}"
+                )
         except Exception as e:
             return False, str(e)
 

--- a/airbyte-integrations/connectors/source-appmetrica-logs-api/source_appmetrica_logs_api/spec.json
+++ b/airbyte-integrations/connectors/source-appmetrica-logs-api/source_appmetrica_logs_api/spec.json
@@ -209,11 +209,11 @@
             ]
           },
           {
-            "title" : "Split Logs",
+            "title" : "Split Logs By Days",
             "type" : "object",
             "properties" : {
               "split_mode_type" : {
-                "const" : "split_date_mode",
+                "const" : "split_days_mode",
                 "order" : 0,
                 "type" : "string"
               },
@@ -230,6 +230,30 @@
             "required" : [
               "split_mode_type",
               "split_range_days_count"
+            ]
+          },
+          {
+            "title" : "Split Logs By Hours",
+            "type" : "object",
+            "properties" : {
+              "split_mode_type" : {
+                "const" : "split_hours_mode",
+                "order" : 0,
+                "type" : "string"
+              },
+              "split_range_hours_count" : {
+                "title" : "Split Range Hours Count",
+                "description" : "E.g. if you choose 6 hours, whole logs will be split into several reports by 6 hours. It can increase replication time, so don't set too small range. Minimum - 6 or 12 (This feature allows you to split it into hours if the source produces too much data (for example, more than 5 GB in one day, which is the appmetrica limit))",
+                "minimum" : 1,
+                "maximum" : 24,
+                "type" : "integer",
+                "default" : "6",
+                "order" : 1
+              }
+            },
+            "required" : [
+              "split_mode_type",
+              "split_range_hours_count"
             ]
           }
         ]

--- a/airbyte-integrations/connectors/source-appmetrica-logs-api/source_appmetrica_logs_api/streams/logs_api/stream.py
+++ b/airbyte-integrations/connectors/source-appmetrica-logs-api/source_appmetrica_logs_api/streams/logs_api/stream.py
@@ -81,7 +81,7 @@ class AppmetricaLogsApi(HttpStream):
         return params
 
     def request_params(
-        self, stream_slice: Mapping[str, any] = None, *args, **kwargs
+        self, stream_slice: Mapping[str, Any] = None, *args, **kwargs
     ) -> MutableMapping[str, Any]:
         params = {
             "application_id": self.application_id,
@@ -110,7 +110,7 @@ class AppmetricaLogsApi(HttpStream):
 
         return schema
 
-    def make_request(self, stream_slice: Mapping[str, any] = None) -> requests.Response:
+    def make_request(self, stream_slice: Mapping[str, Any] = None) -> requests.Response:
         response = requests.get(
             self.url_base + self.path(),
             headers={"Authorization": f"OAuth {self._token}"},
@@ -161,9 +161,11 @@ class AppmetricaLogsApi(HttpStream):
         for chunk in pd.read_csv(
             response.raw,
             compression=compression,
-            encoding='utf-8',
+            encoding="utf-8",
             chunksize=10_000,
-            iterator=True,
+            # iterator=True,
+            dtype_backend="numpy_nullable",
+            engine="c",
         ):
             for col in chunk.columns:
                 # This is to remove warnings from pandas

--- a/airbyte-integrations/connectors/source-appmetrica-logs-api/source_appmetrica_logs_api/utils.py
+++ b/airbyte-integrations/connectors/source-appmetrica-logs-api/source_appmetrica_logs_api/utils.py
@@ -1,19 +1,19 @@
-from typing import Mapping
+from typing import Mapping, Any
 
 import pendulum
 
 
 def get_config_date_range(
-    config: Mapping[str, any],
+    config: Mapping[str, Any],
 ) -> tuple[pendulum.DateTime, pendulum.DateTime]:
-    date_range: Mapping[str, any] = config.get("date_range", {})
+    date_range: Mapping[str, Any] = config.get("date_range", {})
     date_range_type: str = date_range.get("date_range_type")
 
     time_from: pendulum.DateTime | None = None
     time_to: pendulum.DateTime | None = None
 
     # Meaning is date but storing time since later will use time
-    today_date: pendulum.datetime = pendulum.now().replace(
+    today_date: pendulum.DateTime = pendulum.now().replace(
         hour=0, minute=0, second=0, microsecond=0
     )
 
@@ -33,7 +33,9 @@ def get_config_date_range(
         else:
             time_to = today_date.subtract(days=1)
 
+    # Appmetrica uses datetime, so to get records for january 1st
+    # date_from must be 01.01.2025 00:00:00 and date_to 01.01.2025 23:59:59
     return (
         time_from,
-        time_to,
+        time_to.replace(hour=23, minute=59, second=59, microsecond=999999),
     )

--- a/airbyte-integrations/connectors/source-mindbox/source_mindbox/mindbox_service.py
+++ b/airbyte-integrations/connectors/source-mindbox/source_mindbox/mindbox_service.py
@@ -47,7 +47,8 @@ class MindboxService:
             },
         )
 
-    def start_operation_task(self, operation: str, json_payload: dict[str, Any] = {}) -> OperationTaskStatus:
+    def start_operation_task(self, operation: str, json_payload: dict[str, Any] = None) -> OperationTaskStatus:
+        json_payload = json_payload if json_payload else {}
         self._logger.info(f"Start operation {operation} export, json_payload: {json_payload}")
         status = self._api_call(
             "operations/sync",

--- a/airbyte-integrations/connectors/source-mindbox/source_mindbox/schemas/eksport_nps_oprosov.json
+++ b/airbyte-integrations/connectors/source-mindbox/source_mindbox/schemas/eksport_nps_oprosov.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "CustomerIdsMindboxId": { "type": ["string", "null"] },
+    "CustomerActionActionTemplateIdsSystemName": { "type": ["string", "null"] },
+    "CustomerActionActionTemplateName": { "type": ["string", "null"] },
+    "CustomerActionDateTimeUtc": { "type": ["string", "null"] },
+    "CustomerActionCustomFieldsKommentarijizpopapa": { "type": ["string", "null"] },
+    "CustomerActionCustomFieldsOcenkavpopape": { "type": ["string", "null"] },
+    "CustomerActionCustomFieldsURLnakotorombylpokaz": { "type": ["string", "null"] }
+  }
+}

--- a/airbyte-integrations/connectors/source-mindbox/source_mindbox/source.py
+++ b/airbyte-integrations/connectors/source-mindbox/source_mindbox/source.py
@@ -226,6 +226,12 @@ class NpsOprosTutu(MindboxStream):
     operation_name = "NpsOprosTutu"
 
 
+class EksportNpsOprosov(MindboxStream):
+    use_date_range = True
+    primary_key = "CustomerIdsMindboxId"
+    operation_name = "EksportNpsOprosov"
+
+
 # Source
 class SourceMindbox(AbstractSource):
     def check_connection(self, logger, config) -> Tuple[bool, any]:
@@ -301,4 +307,5 @@ class SourceMindbox(AbstractSource):
             Abcartabandjul24var1(**shared_kwargs),
             Abcartabandjul24var2(**shared_kwargs),
             NpsOprosTutu(**shared_kwargs),
+            EksportNpsOprosov(**shared_kwargs),
         ]


### PR DESCRIPTION
- Добавил возможность сплитовать даты в аппметрике по часам (Appmetrica LogsApi имеет лимит в 5ГБ в ответе, поэтому, если данные даже за день больше этого лимита, возвращался пустой бинарник, на котором падал pandas)

- Добавил новый стрим EksportNpsOprosov для mindbox (возможно в схеме не совсем точные поля, брал из ТЗ - https://docs.google.com/document/d/197l-zPv4cwtq4QTSEZw_4zquF4Wv_2mW7UF24IWpcFE/edit?tab=t.0#heading=h.9u0octe211rp)